### PR TITLE
Reduce allocations for special source cases

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,22 @@
+// Copyright 2013 Sonia Keys.
+// Licensed under MIT license.  See "license" file in this source tree.
+
+package internal
+
+import "image"
+
+// PxRGBAfunc returns function to get RGBA color values at (x, y) coordinates of
+// image img. Returned function works the same as img.At(x, y).RGBA() but
+// implements special cases for certain image types to use type-specific methods
+// bypassing color.Color interface which escapes to the heap.
+func PxRGBAfunc(img image.Image) func(x, y int) (r, g, b, a uint32) {
+	switch img0 := img.(type) {
+	case *image.RGBA:
+		return func(x, y int) (r, g, b, a uint32) { return img0.RGBAAt(x, y).RGBA() }
+	case *image.NRGBA:
+		return func(x, y int) (r, g, b, a uint32) { return img0.NRGBAAt(x, y).RGBA() }
+	case *image.YCbCr:
+		return func(x, y int) (r, g, b, a uint32) { return img0.YCbCrAt(x, y).RGBA() }
+	}
+	return func(x, y int) (r, g, b, a uint32) { return img.At(x, y).RGBA() }
+}


### PR DESCRIPTION
R,G,B color values of each source image pixel were read with
image.Image.At() method returning color.Color interface. This is quite
taxing allocation-wise since interface values should be allocated on
heap. Introduce special cases for some concrete source types to read
color values using type-specific methods.

```
name       old time/op    new time/op    delta
pkg:github.com/soniakeys/quant/mean goos:darwin goarch:amd64
Palette-4     1.48s ± 3%     0.62s ± 2%  -58.38%  (p=0.008 n=5+5)
pkg:github.com/soniakeys/quant/median goos:darwin goarch:amd64
Palette-4     284ms ± 2%     133ms ± 2%  -53.26%  (p=0.008 n=5+5)

name       old alloc/op   new alloc/op   delta
pkg:github.com/soniakeys/quant/mean goos:darwin goarch:amd64
Palette-4     129MB ± 0%       6MB ± 0%  -95.32%  (p=0.000 n=4+5)
pkg:github.com/soniakeys/quant/median goos:darwin goarch:amd64
Palette-4    29.4MB ± 0%     7.6MB ± 0%  -74.20%  (p=0.029 n=4+4)

name       old allocs/op  new allocs/op  delta
pkg:github.com/soniakeys/quant/mean goos:darwin goarch:amd64
Palette-4     30.8M ± 0%      0.0M ± 0%     ~     (p=0.079 n=4+5)
pkg:github.com/soniakeys/quant/median goos:darwin goarch:amd64
Palette-4     5.46M ± 0%     0.00M ± 0%  -99.99%  (p=0.008 n=5+5)
```